### PR TITLE
Provide commandline arguments to Java

### DIFF
--- a/MyApp.java
+++ b/MyApp.java
@@ -6,7 +6,11 @@ public class MyApp {
 		TestClass t = new TestClass();
 		
 		new HelloWorldWriter("Hello Test 987654321");
-		
+
+		//Commandline-Arguments
+		if (args != null && args.length >= 1) {
+			System.out.println("Java-Commandline-Args: " + String.join(" ", args));
+		}
 	}	
 }
 

--- a/MyApp.ps1
+++ b/MyApp.ps1
@@ -8,5 +8,6 @@ $PROG="MyApp"	# Name of you public Java class, Filename must match $PROG.java
 $MODE="JAR"		# JAR: a Jar-File ($PROG.jar) is created, DIR: Class-Files are created in a Subdirectory (./$PROG/...)
 $COMPILE=0 		# 0: Compile when necessary, 1: Compile on every run
 
+
 # Start your Java application 
-Start-App
+Start-App -commandlineArgs $args

--- a/MyApp.sh
+++ b/MyApp.sh
@@ -9,4 +9,4 @@ MODE="JAR" 		# JAR: a Jar-File ($PROG.jar) is created, DIR: Class-Files are crea
 COMPILE=0  		# 0: Compile when necessary, 1: Compile on every run
 
 # Start your Java application 
-start
+start "$*"

--- a/ScriptingWithJava.ps1
+++ b/ScriptingWithJava.ps1
@@ -46,19 +46,24 @@ function Compile-App {
 }
 
 function Execute-App {
+    Param ([System.Array]$commandlineArgs)
+
     if($MODE -eq "JAR") {
         Write-Output "executing jar..."
-        Invoke-Expression "java -jar `"$PROG.jar`""
+        Invoke-Expression "java -jar `"$PROG.jar`" `"$commandlineArgs`"" 
+       
     }
 
     if($MODE -eq "DIR") {
         Write-Output "executing class..."
-        Invoke-Expression "java -cp `"./$PROG`" `"$PACKAGE.$PROG`""
+        Invoke-Expression "java -cp `"./$PROG`" `"$PACKAGE.$PROG`" `"$commandlineArgs`""
     }
 }
 
-function Start-App {
+function Start-App() { 
+    Param ([System.Array]$commandlineArgs)
+
     Init-App
-    Compile-App
-    Execute-App
+    Compile-App 
+    Execute-App -commandlineArgs $commandlineArgs
 }

--- a/ScriptingWithJava.sh
+++ b/ScriptingWithJava.sh
@@ -41,21 +41,19 @@ compile() {
 }
 
 execute() {
-
     if [ "$MODE" = "JAR" ]; then
         echo "executing jar..."
-        java -jar "$PROG.jar"
+        java -jar "$PROG.jar" "$*"
     fi
 
     if [ "$MODE" = "DIR" ]; then
         echo "executing class..."
-        java -cp "./$PROG" "$PACKAGE.$PROG"
+        java -cp "./$PROG" "$PACKAGE.$PROG" "$*"
     fi
 }
-
 
 start() {
 	init
 	compile
-	execute
+	execute "$*"
 }


### PR DESCRIPTION
Provide commandline arguments to Java by calling PowerShell- or Bash-Script with parameters.